### PR TITLE
Bump version bounds for binary

### DIFF
--- a/distributed-process-systest.cabal
+++ b/distributed-process-systest.cabal
@@ -15,7 +15,7 @@ library
   exposed-modules:   Control.Distributed.Process.SysTest.Utils
   Build-Depends:     base >= 4.4 && < 5,
                      ansi-terminal >= 0.5 && < 0.7,
-                     binary >= 0.5 && < 0.8,
+                     binary >= 0.5 && < 0.9,
                      bytestring >= 0.9 && < 0.11,
                      distributed-process >= 0.6.0 && < 0.7,
                      distributed-static,


### PR DESCRIPTION
We need binary 0.8.* for LTS 7.16.