### PR TITLE
support GHC 8.2

### DIFF
--- a/distributed-process-systest.cabal
+++ b/distributed-process-systest.cabal
@@ -22,7 +22,7 @@ library
                      ansi-terminal >= 0.5 && < 0.7,
                      binary >= 0.5 && < 0.9,
                      bytestring >= 0.9 && < 0.11,
-                     distributed-process >= 0.6.1 && < 0.7,
+                     distributed-process >= 0.6.1 && < 0.8,
                      distributed-static,
                      HUnit >= 1.2 && < 1.6,
                      network-transport >= 0.4.1.0 && < 0.5,


### PR DESCRIPTION
This compiles successfully with the hackage versions of distributed-process albeit with some warnings regarding deprecated `finally` and `catch` due to a deprecated module.